### PR TITLE
SC-46: Add main TabBar navigation component

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,8 +1,6 @@
 name: Deploy app to GitHub Pages
 
 on:
-  push:
-    branches: ["dev"]
   workflow_dispatch:
 
 env:

--- a/src/app/layout/components/footer/footer.component.html
+++ b/src/app/layout/components/footer/footer.component.html
@@ -1,9 +1,5 @@
-<div class="footer">
-  <span class="font-normal">by</span>
-  <span class="font-medium ml-1">Andrii Kitsun</span>
-
-  <a href="https://github.com/AndriiKitsun" target="_blank" class="ml-2">
-    <i class="pi pi-github"></i>
-  </a>
-</div>
+<footer class="footer">
+  <span>Solar Control by</span>
+  <a href="https://github.com/AndriiKitsun" target="_blank" class="text-primary font-bold hover:underline">Andrii Kitsun</a>
+</footer>
 

--- a/src/app/layout/components/footer/footer.component.scss
+++ b/src/app/layout/components/footer/footer.component.scss
@@ -1,8 +1,8 @@
 .footer {
-  transition: margin-left var(--transition-duration);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-top: 1rem;
-  border-top: 1px solid var(--surface-border);
+  padding: 1rem 0 1rem 0;
+  gap: 0.5rem;
+  border-top: 1px solid var(--content-border-color);
 }

--- a/src/app/layout/components/footer/footer.component.ts
+++ b/src/app/layout/components/footer/footer.component.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-footer',
   standalone: true,
-  imports: [],
   templateUrl: './footer.component.html',
   styleUrl: './footer.component.scss',
 })

--- a/src/app/layout/components/header/header.component.html
+++ b/src/app/layout/components/header/header.component.html
@@ -1,12 +1,10 @@
-<div class="header">
-  <div class="header-logo-container">
-    <button pRipple type="button" class="header-button">
-      <i class="pi pi-bars"></i>
-    </button>
-
+<header class="header">
+  <div class="header-logo-container gap-8">
     <a class="header-logo" routerLink="/">
       <span>Solar Control</span>
     </a>
+
+<!--    <app-tab-bar></app-tab-bar>-->
   </div>
 
   <div class="header-actions-container">
@@ -25,4 +23,4 @@
       </button>
     </app-theme-configurator>
   </div>
-</div>
+</header>

--- a/src/app/layout/components/header/header.component.html
+++ b/src/app/layout/components/header/header.component.html
@@ -3,8 +3,6 @@
     <a class="header-logo" routerLink="/">
       <span>Solar Control</span>
     </a>
-
-<!--    <app-tab-bar></app-tab-bar>-->
   </div>
 
   <div class="header-actions-container">

--- a/src/app/layout/components/header/header.component.html
+++ b/src/app/layout/components/header/header.component.html
@@ -1,5 +1,5 @@
 <header class="header">
-  <div class="header-logo-container gap-8">
+  <div class="header-logo-container">
     <a class="header-logo" routerLink="/">
       <span>Solar Control</span>
     </a>

--- a/src/app/layout/components/header/header.component.scss
+++ b/src/app/layout/components/header/header.component.scss
@@ -1,26 +1,17 @@
 @use "mixins";
 
 .header {
-  position: fixed;
   height: 4rem;
-  left: 0;
-  top: 0;
-  width: 100%;
   padding: 0 2rem;
   background-color: var(--content-card-background);
-  transition: left var(--layout-section-transition-duration);
+  transition: left var(--transition-duration);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  box-shadow: 0 3px 5px rgba(0,0,0,.02), 0 0 2px rgba(0,0,0,.05), 0 1px 4px rgba(0,0,0,.08);
 
   &-logo-container {
     display: flex;
     align-items: center;
-
-    .header-button {
-      margin-right: 0.5rem;
-    }
 
     .header-logo {
       display: inline-flex;

--- a/src/app/layout/components/header/header.component.scss
+++ b/src/app/layout/components/header/header.component.scss
@@ -4,7 +4,6 @@
   height: 4rem;
   padding: 0 2rem;
   background-color: var(--content-card-background);
-  transition: left var(--transition-duration);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -21,7 +20,6 @@
       color: var(--text-color);
       font-weight: 500;
       gap: 0.5rem;
-
 
       &:focus-visible {
         @include mixins.focused();
@@ -42,7 +40,6 @@
     border-radius: 50%;
     width: 2.5rem;
     height: 2.5rem;
-    transition: background-color var(--transition-duration);
     cursor: pointer;
 
     &:hover {

--- a/src/app/layout/components/header/header.component.ts
+++ b/src/app/layout/components/header/header.component.ts
@@ -5,11 +5,18 @@ import { StyleClass } from 'primeng/styleclass';
 import { RouterLink } from '@angular/router';
 import { PrimeIcons } from 'primeng/api';
 import { ColorScheme, LayoutService } from '../../services';
+import { TabBarComponent } from '../tab-bar/tab-bar.component';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [Ripple, RouterLink, ThemeConfiguratorComponent, StyleClass],
+  imports: [
+    Ripple,
+    RouterLink,
+    ThemeConfiguratorComponent,
+    StyleClass,
+    TabBarComponent,
+  ],
   templateUrl: './header.component.html',
   styleUrl: './header.component.scss',
 })

--- a/src/app/layout/components/layout/layout.component.html
+++ b/src/app/layout/components/layout/layout.component.html
@@ -1,14 +1,13 @@
 <div class="layout">
-  <app-header />
-
-  <div class="layout-menu">
-    <app-menu />
+  <div class="layout-header">
+    <app-header />
+    <app-tab-bar></app-tab-bar>
   </div>
 
-  <div class="layout-main-container">
-    <div class="layout-main">
+  <div class="layout-main">
+    <main class="layout-main__content">
       <router-outlet></router-outlet>
-    </div>
+    </main>
 
     <app-footer />
   </div>

--- a/src/app/layout/components/layout/layout.component.scss
+++ b/src/app/layout/components/layout/layout.component.scss
@@ -15,7 +15,6 @@
     min-height: 100vh;
     justify-content: space-between;
     padding: 9rem 2rem 0 2rem;
-    transition: margin-left var(--transition-duration);
 
     &__content {
       flex: 1 1 auto;

--- a/src/app/layout/components/layout/layout.component.scss
+++ b/src/app/layout/components/layout/layout.component.scss
@@ -1,34 +1,25 @@
 .layout {
   min-height: 100vh;
 
-  &-menu {
+  &-header {
     position: fixed;
-    width: 20rem;
-    height: calc(100vh - 8rem);
-    overflow-y: auto;
-    user-select: none;
-    top: 6rem;
-    left: 2rem;
-    transition:
-      transform var(--layout-section-transition-duration),
-      left var(--layout-section-transition-duration);
-    background-color: var(--content-card-background);
-    border-radius: var(--content-border-radius);
-    padding: 0.5rem 1.5rem;
+    left: 0;
+    top: 0;
+    width: 100%;
+    box-shadow: 0 3px 5px rgba(0,0,0,.02), 0 0 2px rgba(0,0,0,.05), 0 1px 4px rgba(0,0,0,.08);
   }
 
-  &-main-container {
+  &-main {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
     justify-content: space-between;
-    padding: 6rem 2rem 2px 2.5rem;
+    padding: 9rem 2rem 0 2rem;
     transition: margin-left var(--transition-duration);
-    margin-left: 300px;
-  }
 
-  &-main {
-    flex: 1 1 auto;
-    border-radius: var(--content-border-radius);
+    &__content {
+      flex: 1 1 auto;
+      border-radius: var(--content-border-radius);
+    }
   }
 }

--- a/src/app/layout/components/layout/layout.component.ts
+++ b/src/app/layout/components/layout/layout.component.ts
@@ -1,14 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { HeaderComponent } from '../header/header.component';
-import { MenuComponent } from '../menu/menu.component';
 import { LayoutService } from '../../services';
 import { RouterOutlet } from '@angular/router';
 import { FooterComponent } from '../footer/footer.component';
+import { TabBarComponent } from '../tab-bar/tab-bar.component';
 
 @Component({
   selector: 'app-layout',
   standalone: true,
-  imports: [HeaderComponent, MenuComponent, RouterOutlet, FooterComponent],
+  imports: [HeaderComponent, TabBarComponent, RouterOutlet, FooterComponent],
   templateUrl: './layout.component.html',
   styleUrl: './layout.component.scss',
 })

--- a/src/app/layout/components/tab-bar/tab-bar.component.html
+++ b/src/app/layout/components/tab-bar/tab-bar.component.html
@@ -1,0 +1,12 @@
+<p-tabs [value]="activeRoute()" class="tab-bar">
+  <p-tablist>
+    <div class="tab-bar__list">
+      @for (tab of tabs; track tab.label) {
+        <p-tab [value]="tab.route" [routerLink]="tab.route" class="tab-bar__tab">
+          <i [class]="tab.icon"></i>
+          <span>{{ tab.label }}</span>
+        </p-tab>
+      }
+    </div>
+  </p-tablist>
+</p-tabs>

--- a/src/app/layout/components/tab-bar/tab-bar.component.scss
+++ b/src/app/layout/components/tab-bar/tab-bar.component.scss
@@ -1,0 +1,10 @@
+.tab-bar {
+  &__list {
+    display: flex;
+    padding: 0 2rem;
+  }
+
+  &__tab {
+    height: 3rem;
+  }
+}

--- a/src/app/layout/components/tab-bar/tab-bar.component.spec.ts
+++ b/src/app/layout/components/tab-bar/tab-bar.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TabBarComponent } from './tab-bar.component';
+
+describe('TabBarComponent', () => {
+  let component: TabBarComponent;
+  let fixture: ComponentFixture<TabBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TabBarComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TabBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/layout/components/tab-bar/tab-bar.component.spec.ts
+++ b/src/app/layout/components/tab-bar/tab-bar.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TabBarComponent } from './tab-bar.component';
+import { ActivatedRoute } from '@angular/router';
 
 describe('TabBarComponent', () => {
   let component: TabBarComponent;
@@ -8,6 +9,12 @@ describe('TabBarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TabBarComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {},
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TabBarComponent);

--- a/src/app/layout/components/tab-bar/tab-bar.component.ts
+++ b/src/app/layout/components/tab-bar/tab-bar.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit, signal, inject, DestroyRef } from '@angular/core';
+import { Tab, TabList, Tabs } from 'primeng/tabs';
+import { RoutePath } from '@common/constants/router.constants';
+import { RouterLink, Router, NavigationEnd } from '@angular/router';
+import { tap, filter, map, startWith } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MAIN_TABS, ROUTE_REGEX } from './tab-bar.constants';
+import { TabItem } from './tab-bar.types';
+
+@Component({
+  selector: 'app-tab-bar',
+  standalone: true,
+  imports: [Tab, TabList, Tabs, RouterLink],
+  templateUrl: './tab-bar.component.html',
+  styleUrl: './tab-bar.component.scss',
+})
+export class TabBarComponent implements OnInit {
+  tabs: TabItem[] = MAIN_TABS;
+  activeRoute = signal('');
+
+  private destroyRef = inject(DestroyRef);
+
+  constructor(private readonly router: Router) {}
+
+  ngOnInit(): void {
+    this.getActiveRoute();
+  }
+
+  getActiveRoute(): void {
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        map((event) => event.urlAfterRedirects),
+        startWith(this.router.url),
+        tap((url) => {
+          const route = url.split(ROUTE_REGEX).at(1) ?? RoutePath.LANDING;
+
+          this.activeRoute.set(route);
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+}

--- a/src/app/layout/components/tab-bar/tab-bar.constants.ts
+++ b/src/app/layout/components/tab-bar/tab-bar.constants.ts
@@ -1,0 +1,23 @@
+import { TabItem } from './tab-bar.types';
+import { RoutePath } from '@common/constants/router.constants';
+import { PrimeIcons } from 'primeng/api';
+
+export const MAIN_TABS: TabItem[] = [
+  {
+    label: 'Dashboard',
+    icon: PrimeIcons.HOME,
+    route: RoutePath.LANDING,
+  },
+  {
+    label: 'Stations',
+    icon: PrimeIcons.WAREHOUSE,
+    route: RoutePath.STATIONS,
+  },
+  {
+    label: 'Miners',
+    icon: PrimeIcons.SERVER,
+    route: RoutePath.MINERS,
+  },
+];
+
+export const ROUTE_REGEX = /[/?]/;

--- a/src/app/layout/components/tab-bar/tab-bar.types.ts
+++ b/src/app/layout/components/tab-bar/tab-bar.types.ts
@@ -1,0 +1,5 @@
+export interface TabItem {
+  label: string;
+  icon: string;
+  route: string;
+}

--- a/src/app/layout/components/theme-configurator/theme-configurator.component.scss
+++ b/src/app/layout/components/theme-configurator/theme-configurator.component.scss
@@ -1,5 +1,6 @@
 .theme-configurator {
   position: relative;
+  z-index: 1;
 
   &-panel {
     position: absolute;

--- a/src/app/layout/services/layout/layout.service.ts
+++ b/src/app/layout/services/layout/layout.service.ts
@@ -54,7 +54,11 @@ export class LayoutService {
         ? ColorScheme.DARK
         : ColorScheme.LIGHT;
 
-    document.documentElement.classList.toggle(LayoutService.darkModeClassKey);
+    if (document.startViewTransition) {
+      document.startViewTransition(() => this.toggleDarkModeClass());
+    } else {
+      this.toggleDarkModeClass();
+    }
 
     localStorage.setItem(LayoutService.colorSchemeKey, this.colorScheme);
   }
@@ -169,5 +173,9 @@ export class LayoutService {
         },
       },
     }) as ThemePreset;
+  }
+
+  private toggleDarkModeClass(): void {
+    document.documentElement.classList.toggle(LayoutService.darkModeClassKey);
   }
 }

--- a/src/app/views/solar/components/miners/miners.component.html
+++ b/src/app/views/solar/components/miners/miners.component.html
@@ -1,1 +1,3 @@
-<p>miners works!</p>
+<div class="menu">
+  <app-menu></app-menu>
+</div>

--- a/src/app/views/solar/components/miners/miners.component.scss
+++ b/src/app/views/solar/components/miners/miners.component.scss
@@ -1,0 +1,14 @@
+.menu {
+  width: 20rem;
+  height: calc(100vh - 8rem);
+  overflow-y: auto;
+  user-select: none;
+  top: 6rem;
+  left: 2rem;
+  transition:
+    transform var(--transition-duration),
+    left var(--transition-duration);
+  background-color: var(--content-card-background);
+  border-radius: var(--content-border-radius);
+  padding: 0.5rem 1.5rem;
+}

--- a/src/app/views/solar/components/miners/miners.component.scss
+++ b/src/app/views/solar/components/miners/miners.component.scss
@@ -5,9 +5,6 @@
   user-select: none;
   top: 6rem;
   left: 2rem;
-  transition:
-    transform var(--transition-duration),
-    left var(--transition-duration);
   background-color: var(--content-card-background);
   border-radius: var(--content-border-radius);
   padding: 0.5rem 1.5rem;

--- a/src/app/views/solar/components/miners/miners.component.spec.ts
+++ b/src/app/views/solar/components/miners/miners.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { MinersComponent } from './miners.component';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
 
 describe('MinersComponent', () => {
   let component: MinersComponent;
@@ -8,7 +9,13 @@ describe('MinersComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MinersComponent],
+      imports: [MinersComponent, NoopAnimationsModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {},
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MinersComponent);

--- a/src/app/views/solar/components/miners/miners.component.ts
+++ b/src/app/views/solar/components/miners/miners.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
+import { MenuComponent } from '@layout/components/menu/menu.component';
 
 @Component({
   selector: 'app-miners',
   standalone: true,
-  imports: [],
+  imports: [MenuComponent],
   templateUrl: './miners.component.html',
   styleUrl: './miners.component.scss',
 })

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+interface Document {
+  startViewTransition(updateCallback: () => void): void;
+}

--- a/src/styles/variables/_common.scss
+++ b/src/styles/variables/_common.scss
@@ -4,7 +4,6 @@
 
   --text-color: var(--p-text-color);
 
-  --layout-section-transition-duration: 0.2s;
   --transition-duration: var(--p-transition-duration);
 
   --disabled-opacity: var(--p-disabled-opacity);


### PR DESCRIPTION
## Description

Scope:
- Add main TabBar navigation component

Other fixes & changes:
- Remove auto-deployment on push events to reduce workflow cost
- Fix transition after dark mode switching
- Update footer
- Refactor header layout (for now, the layout component decides the position and sizes of the header and tab bar components)
- Fix z-index of theme-configuratior component
- Delete redundant transitions
- Add some semantic tags
- Delete the redundant menu button from the header

## Before
![image](https://github.com/user-attachments/assets/cf83442f-40d6-4601-b860-30cde33416d8)


## After

![image](https://github.com/user-attachments/assets/234ad4ed-95e0-4e3c-be72-cce258c54562)
