### PR TITLE
SC-81: Selected menu loses focus on menu blur

### DIFF
--- a/.changeset/eleven-toes-change.md
+++ b/.changeset/eleven-toes-change.md
@@ -1,0 +1,5 @@
+---
+'solar-control-fe': patch
+---
+
+SC-81: Selected menu loses focus on menu blur

--- a/src/app/views/asics/asics.component.html
+++ b/src/app/views/asics/asics.component.html
@@ -1,5 +1,6 @@
 <div class="asics" *transloco="let t">
   <p-menu
+    #menu
     [model]="(menuItems$ | async)!"
     styleClass="w-72 h-full overflow-auto"
   >

--- a/src/app/views/asics/asics.component.ts
+++ b/src/app/views/asics/asics.component.ts
@@ -1,4 +1,11 @@
-import { Component, OnInit, signal, computed } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  signal,
+  computed,
+  AfterViewInit,
+  ViewChild,
+} from '@angular/core';
 import { map, Observable, tap, first } from 'rxjs';
 import { Menu } from 'primeng/menu';
 import { Button } from 'primeng/button';
@@ -38,10 +45,12 @@ import { TableModule } from 'primeng/table';
   styleUrl: './asics.component.scss',
   providers: [ConfirmationService],
 })
-export class AsicsComponent implements OnInit {
+export class AsicsComponent implements OnInit, AfterViewInit {
   isLoading = signal(false);
   isToolbarDisabled = computed(() => this.isLoading() || !this.selectedItem());
   selectedItem = signal<AsicMenuItem | null>(null);
+
+  @ViewChild('menu') menuElement!: Menu;
 
   menuItems$!: Observable<AsicMenuItem[]>;
 
@@ -57,6 +66,16 @@ export class AsicsComponent implements OnInit {
 
   ngOnInit(): void {
     this.menuItems$ = this.getMenuItems();
+  }
+
+  ngAfterViewInit(): void {
+    setTimeout(() => {
+      if (this.menuElement) {
+        // Override method to prevent menu item focus lose
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        this.menuElement.onListBlur = () => {};
+      }
+    }, 100);
   }
 
   getMenuItems(): Observable<AsicMenuItem[]> {


### PR DESCRIPTION
## Description

- Unfortunately, PrimeNG menu does not have a configuration to persist the focus state of menu items. After clicking outside the menu element, the menu API emits a blur event and unfocuses the selected item. To prevent loss of focus, the `onListBlur` method has been overridden.
