### PR TITLE
SC-83: [Asics] Add duration time and current perf preset

### DIFF
--- a/.changeset/serious-crews-rescue.md
+++ b/.changeset/serious-crews-rescue.md
@@ -1,0 +1,5 @@
+---
+'solar-control-fe': minor
+---
+
+SC-83: [Asics] Add duration time and current perf preset

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -34,6 +34,7 @@
       "COLUMN": {
         "IP_ADDRESS": "IP Address",
         "STATE": "Status",
+        "TIME": "Time",
         "AVERAGE_HASHRATE": "Avg. Hashrate (TH/s)",
         "MAX_TEMP": "Max Temperature (°C)",
         "POWER_USAGE": "Power Usage (kW)",
@@ -48,7 +49,8 @@
         "SHUTTING-DOWN": "Shutting down",
         "STOPPED": "Stopped",
         "FAILURE": "Failure"
-      }
+      },
+      "TIME_FORMAT": "{{days}}d {{hours}}h {{minutes}}m"
     }
   },
   "SENSORS": {

--- a/public/i18n/uk.json
+++ b/public/i18n/uk.json
@@ -34,6 +34,7 @@
       "COLUMN": {
         "IP_ADDRESS": "IP Адреса",
         "STATE": "Статус",
+        "TIME": "Час",
         "AVERAGE_HASHRATE": "Сер. Хешрейт (Тх/с)",
         "MAX_TEMP": "Макс. Температура (°C)",
         "POWER_USAGE": "Споживання (кВт)",
@@ -48,7 +49,8 @@
         "SHUTTING-DOWN": "Вимкнення",
         "STOPPED": "Зупинено",
         "FAILURE": "Помилка"
-      }
+      },
+      "TIME_FORMAT": "{{days}}д {{hours}}г {{minutes}}хв"
     }
   },
   "SENSORS": {

--- a/src/app/views/asics/asics.component.html
+++ b/src/app/views/asics/asics.component.html
@@ -54,6 +54,7 @@
                 {{ t('ASICS.TABLE.COLUMN.IP_ADDRESS') }}
               </th>
               <th class="table__column">{{ t('ASICS.TABLE.COLUMN.STATE') }}</th>
+              <th class="table__column">{{ t('ASICS.TABLE.COLUMN.TIME') }}</th>
               <th class="table__column">
                 {{ t('ASICS.TABLE.COLUMN.AVERAGE_HASHRATE') }}
               </th>
@@ -84,6 +85,16 @@
                   [value]="t(summary.state.value)"
                   [severity]="summary.state.severity"
                 />
+              </td>
+
+              <td>
+                {{
+                  t('ASICS.TABLE.TIME_FORMAT', {
+                    days: summary.time.days,
+                    hours: summary.time.hours,
+                    minutes: summary.time.minutes,
+                  })
+                }}
               </td>
 
               <td>{{ summary.avgHashRate }}</td>

--- a/src/app/views/asics/asics.component.scss
+++ b/src/app/views/asics/asics.component.scss
@@ -6,6 +6,6 @@
 
 .table {
   &__column {
-    width: calc(100% / 6);
+    width: calc(100% / 7);
   }
 }

--- a/src/app/views/asics/asics.component.ts
+++ b/src/app/views/asics/asics.component.ts
@@ -194,10 +194,18 @@ export class AsicsComponent implements OnInit, AfterViewInit {
         const gridData: AsicSummaryGridItem = {
           ip: summary.ip,
           state: {
-            value: `ASICS.TABLE.STATE.${summary.state.toUpperCase()}`,
-            severity: this.getStateSeverity(summary.state),
+            value: `ASICS.TABLE.STATE.${summary.status.state.toUpperCase()}`,
+            severity: this.getStateSeverity(summary.status.state),
           },
-          avgHashRate: formatNum(summary.avgHashRate, TWO_DIGIT),
+          time: {
+            days: summary.status.stateTimeDays,
+            hours: summary.status.stateTimeHours,
+            minutes: summary.status.stateTimeMinutes,
+          },
+          avgHashRate: this.formatHashRate(
+            summary.avgHashRate,
+            summary.currentPreset,
+          ),
           maxChipTemp: formatNum(summary.maxChipTemp, NEAREST_INT),
           powerConsumption: formatNum(summary.powerConsumption, NEAREST_INT),
           avgFanSpeed: formatNum(summary.avgFanSpeed, NEAREST_INT),
@@ -215,6 +223,16 @@ export class AsicsComponent implements OnInit, AfterViewInit {
         throw err;
       }),
     );
+  }
+
+  formatHashRate(hashrate: number, preset?: string): string {
+    const formatted = formatNum(hashrate, TWO_DIGIT);
+
+    if (preset) {
+      return `${formatted} / ${preset}`;
+    }
+
+    return formatted;
   }
 
   onItemClick(event: MenuItemCommandEvent): void {

--- a/src/app/views/asics/asics.models.ts
+++ b/src/app/views/asics/asics.models.ts
@@ -24,9 +24,15 @@ export type AsicState =
 export interface AsicSummaryModel {
   hostname: string;
   ip: string;
-  state: AsicState;
+  status: {
+    state: AsicState;
+    stateTimeDays: number;
+    stateTimeHours: number;
+    stateTimeMinutes: number;
+  };
   avgHashRate: number;
   maxChipTemp: number;
   powerConsumption: number;
   avgFanSpeed: number;
+  currentPreset?: string;
 }

--- a/src/app/views/asics/asics.types.ts
+++ b/src/app/views/asics/asics.types.ts
@@ -17,6 +17,11 @@ export interface AsicSummaryGridItem {
     value: string;
     severity: string;
   };
+  time: {
+    days: number;
+    hours: number;
+    minutes: number;
+  };
   avgHashRate: string;
   maxChipTemp: string;
   powerConsumption: string;


### PR DESCRIPTION
## Description

- Add duration time and current perf preset to Asics table

## After

![image](https://github.com/user-attachments/assets/88db045e-b2fd-4839-85d1-acf1872250b7)
