### PR TITLE
SC-155: Add Asic setting to prevent control automation during T2 zone

### DIFF
--- a/.changeset/big-ants-notice.md
+++ b/.changeset/big-ants-notice.md
@@ -1,0 +1,5 @@
+---
+'solar-control-fe': minor
+---
+
+SC-155: Add Asic setting to prevent control automation during T2 zone

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -28,6 +28,7 @@
     "SETTINGS": {
       "AUTOMATED": "Automation",
       "T2_ACTIVE": "Start at night",
+      "T2_AUTOMATED": "Automation at night",
       "T2_END_STOP": "Stop in the morning"
     },
     "TABLE": {
@@ -114,13 +115,13 @@
       "SAVE_MESSAGE": "Are you sure you want to save protection rule?"
     },
     "GROUP": {
-      "AC_OUTPUT_AVG_VOLTAGE": {
-        "LABEL": "AC Output - Avg Voltage",
-        "SUFFIX": " V"
-      },
       "AC_OUTPUT_AVG_FREQUENCY": {
         "LABEL": "AC Output - Avg Frequency",
         "SUFFIX": " Hz"
+      },
+      "AC_OUTPUT_AVG_VOLTAGE": {
+        "LABEL": "AC Output - Avg Voltage",
+        "SUFFIX": " V"
       },
       "AC_OUTPUT_VOLTAGE": {
         "LABEL": "AC Output - Voltage",
@@ -155,11 +156,11 @@
     },
     "TABLE": {
       "COLUMN": {
+        "AVG_FREQUENCY": "Avg F (Hz)",
         "AVG_VOLTAGE": "Avg U (V)",
         "CURRENT": "I (A)",
         "ENERGY": "E (kW⋅h)",
         "ENERGY_CCY_SUM": "E Sum (UAH)",
-        "AVG_FREQUENCY": "Avg F (Hz)",
         "NAME": "Name",
         "POWER": "P (kW)",
         "POWER_FACTOR": "Power factor",

--- a/public/i18n/uk.json
+++ b/public/i18n/uk.json
@@ -28,6 +28,7 @@
     "SETTINGS": {
       "AUTOMATED": "Автоматизація",
       "T2_ACTIVE": "Вмикати вночі",
+      "T2_AUTOMATED": "Автоматизація вночі",
       "T2_END_STOP": "Вимикати вранці"
     },
     "TABLE": {
@@ -114,13 +115,13 @@
       "SAVE_MESSAGE": "Ви впевнені, що бажаєте зберегти правило захисту?"
     },
     "GROUP": {
-      "AC_OUTPUT_AVG_VOLTAGE": {
-        "LABEL": "AC Вихід - Середня напруга",
-        "SUFFIX": " В"
-      },
       "AC_OUTPUT_AVG_FREQUENCY": {
         "LABEL": "AC Вихід - Середня Частота",
         "SUFFIX": " Гц"
+      },
+      "AC_OUTPUT_AVG_VOLTAGE": {
+        "LABEL": "AC Вихід - Середня напруга",
+        "SUFFIX": " В"
       },
       "AC_OUTPUT_VOLTAGE": {
         "LABEL": "AC Вихід - Напруга",
@@ -155,11 +156,11 @@
     },
     "TABLE": {
       "COLUMN": {
+        "AVG_FREQUENCY": "Сер. F (Гц)",
         "AVG_VOLTAGE": "Сер. U (В)",
         "CURRENT": "I (A)",
         "ENERGY": "E (кВт⋅год)",
         "ENERGY_CCY_SUM": "E Сума (грн)",
-        "AVG_FREQUENCY": "Сер. F (Гц)",
         "NAME": "Назва",
         "POWER": "P (кВт)",
         "POWER_FACTOR": "Коеф. потуж.",

--- a/src/app/views/asics/constants/asic-settings.constants.ts
+++ b/src/app/views/asics/constants/asic-settings.constants.ts
@@ -4,6 +4,7 @@ import { AsicSettingGroup } from '../types/asic-settings.types';
  * t(ASICS.SETTINGS.T2_ACTIVE)
  * t(ASICS.SETTINGS.T2_END_STOP)
  * t(ASICS.SETTINGS.AUTOMATED)
+ * t(ASICS.SETTINGS.T2_AUTOMATED)
  * */
 
 export const ASIC_SETTINGS: AsicSettingGroup[] = [
@@ -18,5 +19,9 @@ export const ASIC_SETTINGS: AsicSettingGroup[] = [
   {
     id: 'automated',
     label: 'ASICS.SETTINGS.AUTOMATED',
+  },
+  {
+    id: 't2Automated',
+    label: 'ASICS.SETTINGS.T2_AUTOMATED',
   },
 ];

--- a/src/app/views/asics/models/asics.models.ts
+++ b/src/app/views/asics/models/asics.models.ts
@@ -6,6 +6,7 @@ export interface AsicModel {
   t2Active: boolean;
   t2EndStop: boolean;
   automated: boolean;
+  t2Automated: boolean;
 }
 
 export interface AddAsicModel {
@@ -18,6 +19,7 @@ export interface UpdateAsicModel extends Partial<AddAsicModel> {
   t2Active?: boolean;
   t2EndStop?: boolean;
   automated?: boolean;
+  t2Automated?: boolean;
 }
 
 export type AsicState =

--- a/src/app/views/asics/types/asic-settings.types.ts
+++ b/src/app/views/asics/types/asic-settings.types.ts
@@ -3,7 +3,7 @@ import { TranslationKey } from '@common/types/lang.types';
 
 export type AsicSetting = keyof Pick<
   AsicModel,
-  't2Active' | 't2EndStop' | 'automated'
+  't2Active' | 't2EndStop' | 'automated' | 't2Automated'
 >;
 
 export interface AsicSettingGroup {


### PR DESCRIPTION
## Description

- Add Asic setting to prevent control automation during T2 zone

## Before

![image](https://github.com/user-attachments/assets/8e24779a-728c-464c-a2e6-09e465b58702)

## After

![image](https://github.com/user-attachments/assets/4ce745b4-4794-4ba9-a780-fb3af496d701)
